### PR TITLE
MusicId等数据类型改为Int64

### DIFF
--- a/ncmdumpGUI/NeteaseCopyrightData.cs
+++ b/ncmdumpGUI/NeteaseCopyrightData.cs
@@ -11,7 +11,7 @@ namespace ncmdumpGUI
     class NeteaseCopyrightData
     {
         [DataMember(Name = "musicId")]
-        public int MusicId { get; set; }
+        public Int64 MusicId { get; set; }
 
         [DataMember(Name = "musicName")]
         public string MusicName { get; set; }
@@ -20,7 +20,7 @@ namespace ncmdumpGUI
         public List<List<object>> Artist { get; set; }
 
         [DataMember(Name = "albumId")]
-        public int AlbumId { get; set; }
+        public Int64 AlbumId { get; set; }
 
         [DataMember(Name = "album")]
         public string Album { get; set; }
@@ -41,7 +41,7 @@ namespace ncmdumpGUI
         public int Duration { get; set; }
 
         [DataMember(Name = "mvId")]
-        public int MvId { get; set; }
+        public Int64 MvId { get; set; }
 
         [DataMember(Name = "alias")]
         public List<string> Alias { get; set; }


### PR DESCRIPTION
部分音乐的MusicId大小已经超出了int32范围